### PR TITLE
feat: docs about base reporter and dot reporter

### DIFF
--- a/content/docs/extend/creating-reporters.md
+++ b/content/docs/extend/creating-reporters.md
@@ -137,3 +137,104 @@ emitter.on('runner:end', async () => {
   await release()
 })
 ```
+
+## Base Reporter
+To make it easier for you to write custom reporters, we also provide [`@japa/base-reporter`](https://github.com/japa/base-reporter) which abstracts the repetitive parts of creating test reporters.
+
+First, you need to install the package from npm registry as follows:
+
+```sh
+npm i @japa/base-reporter
+```
+
+Then you have create your reporter as follows:
+
+```ts
+import { BaseReporter } from '@japa/base-reporter'
+
+class MyReporter extends BaseReporter {}
+
+export const reporterFn = (myReporterOptions = {}) => {
+  const myReporter = new MyReporter(myReporterOptions)
+  return myReporter.boot.bind(reporter)
+}
+```
+
+### Handlers
+
+The Base reporter invokes following methods as it receives the events from the runner. You can implement these methods to display the tests progress :
+
+```ts
+import { BaseReporter } from '@japa/base-reporter'
+
+class MyReporter extends BaseReporter {
+  protected onTestStart(payload: TestStartNode) {
+    console.log('test started')
+  }
+  protected onTestEnd(payload: TestEndNode) {
+    console.log('test endeded')
+  }
+
+  protected onGroupStart(payload: GroupStartNode) {
+    console.log('group started')
+  }
+  protected onGroupEnd(payload: GroupEndNode) {
+    console.log('group ended')
+  }
+
+  protected onSuiteStart(payload: SuiteStartNode) {
+    console.log('suite started')
+  }
+  protected onSuiteEnd(payload: SuiteEndNode) {
+    console.log('suite ended')
+  }
+
+  protected async start(payload: RunnerStartNode) {
+    console.log('test runner started. You can run async operations here')
+  }
+  protected async end(payload: RunnerEndNode) {
+    console.log('test runner ended. You can run async operations here')
+  }
+}
+```
+
+### Inherited properties
+The following properties are available on the BaseReporter. These properties are available only after the boot method is called.
+
+#### runner
+Reference to underlying tests runner instance.
+
+```ts
+this.runner
+```
+
+#### currentFileName
+Reference to the file name for which tests are getting executed. The filename is only available inside the test or group handlers.
+
+```ts
+this.currentFileName
+```
+
+#### currentSuiteName
+Reference to the suite name for which tests are getting executed. The suite name is only available after the `onSuiteStart` handler call.
+
+```ts
+this.currentSuiteName
+```
+
+#### uncaughtExceptions
+Uncaught exceptions collected while tests are running. We rely on `process.on('uncaughtException')` event to collect uncaught exceptions and display them with their stack trace at the end.
+
+### Printing tests summary
+After all the tests have been finished, you can call the `printSummary` method to print a detailed summary of all tests alongside pretty diffs and pretty error stack trace.
+
+You should call the `printSummary` method from the `end` handler.
+
+```ts
+class SpecReporter extends BaseReporter {
+  protected async end() {
+    const summary = await this.runner.getSummary()
+    await this.printSummary(summary)
+  }
+}
+```

--- a/content/docs/menu.json
+++ b/content/docs/menu.json
@@ -86,6 +86,11 @@
             "contentPath": "plugins/spec-reporter.md"
           },
           {
+            "title": "Dot reporter",
+            "permalink": "plugins/dot-reporter",
+            "contentPath": "plugins/dot-reporter.md"
+          },
+          {
             "title": "Assert",
             "permalink": "plugins/assert",
             "contentPath": "plugins/assert.md"

--- a/content/docs/plugins/dot-reporter.md
+++ b/content/docs/plugins/dot-reporter.md
@@ -1,0 +1,59 @@
+---
+title: Dot reporter
+description: Minimalist reporter for Japa
+---
+
+# Dot reporter
+
+Reporters in Japa are responsible for displaying/saving the progress of tests. The dot reporter is a minimalist reporter that displays a dot for each passing test and an cross for each failing test.
+
+![](https://user-images.githubusercontent.com/8337858/188954371-959f6171-22c8-4a15-a76f-b9d9c2576ab6.png)
+
+## Installation and setup
+Install the package from the npm registry as follows.
+
+```sh
+npm i -D @japa/dot-reporter
+```
+
+And register it as a reporter within the `bin/test.js` file.
+
+:::languageSwitcher
+
+```ts
+// title: ESM
+// highlight-start
+import { dotReporter } from '@japa/spec-reporter'
+// highlight-end
+import { configure, processCliArgs } from '@japa/runner'
+
+configure({
+  ...processCliArgs(process.argv.slice(2)),
+  ...{
+    files: ['tests/**/*.spec.js']
+    // highlight-start
+    reporters: [dotReporter()]
+    // highlight-end
+  }
+})
+```
+
+```ts
+// title: CommonJS
+// highlight-start
+const { dotRepoter } = require('@japa/spec-reporter')
+// highlight-end
+const { configure, processCliArgs } = require('@japa/runner')
+
+configure({
+  ...processCliArgs(process.argv.slice(2)),
+  ...{
+    files: ['tests/**/*.spec.js']
+    // highlight-start
+    reporters: [dotRepoter()]
+    // highlight-end
+  }
+})
+```
+
+:::

--- a/content/docs/plugins/dot-reporter.md
+++ b/content/docs/plugins/dot-reporter.md
@@ -23,7 +23,7 @@ And register it as a reporter within the `bin/test.js` file.
 ```ts
 // title: ESM
 // highlight-start
-import { dotReporter } from '@japa/spec-reporter'
+import { dotReporter } from '@japa/dot-reporter'
 // highlight-end
 import { configure, processCliArgs } from '@japa/runner'
 
@@ -41,7 +41,7 @@ configure({
 ```ts
 // title: CommonJS
 // highlight-start
-const { dotRepoter } = require('@japa/spec-reporter')
+const { dotRepoter } = require('@japa/dot-reporter')
 // highlight-end
 const { configure, processCliArgs } = require('@japa/runner')
 

--- a/content/docs/plugins/dot-reporter.md
+++ b/content/docs/plugins/dot-reporter.md
@@ -7,7 +7,7 @@ description: Minimalist reporter for Japa
 
 Reporters in Japa are responsible for displaying/saving the progress of tests. The dot reporter is a minimalist reporter that displays a dot for each passing test and an cross for each failing test.
 
-![](https://user-images.githubusercontent.com/8337858/188954371-959f6171-22c8-4a15-a76f-b9d9c2576ab6.png)
+![](https://raw.githubusercontent.com/japa/dot-reporter/develop/assets/reporter.png)
 
 ## Installation and setup
 Install the package from the npm registry as follows.


### PR DESCRIPTION
Just added some documentation for the Base reporter + Dot reporter

The dot reporter documentation was basically copy/pasted from the spec reporter. ( maybe we could document all the reporters on only one page? When we make the next one maybe ? )

And, for the base reporter, I took the content of the README
