### PR TITLE
fix: update link to superagent

### DIFF
--- a/content/docs/plugins/api-client.md
+++ b/content/docs/plugins/api-client.md
@@ -18,7 +18,7 @@ It has out of the box support for:
 - Support for registering custom body serializers and parsers.
 
 :::note
-The plugin is built on top of [superagent](https://visionmedia.github.io/superagent/). However, it is worth noting that it is not a thin wrapper, and therefore the API is somewhat different.
+The plugin is built on top of [superagent](https://ladjs.github.io/superagent/). However, it is worth noting that it is not a thin wrapper, and therefore the API is somewhat different.
 :::
 
 ## Setup


### PR DESCRIPTION
The superagent link was a 404, since the GitHub Pages documentation page had moved to a new GitHub user.