### PR TITLE
Add dark/light/system toggle on the navigation

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -85,18 +85,7 @@ Alpine.data('search', function () {
 
 Alpine.data('darkModeToggle', function () {
   return {
-    currentMode: localStorage.getItem('theme') || 'system',
-
-    init() {
-      if (
-        localStorage.theme === 'dark' ||
-        (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)
-      ) {
-        document.documentElement.classList.add('dark')
-      } else {
-        document.documentElement.classList.remove('dark')
-      }
-    },
+    currentMode: localStorage.getItem('_x_themeColor') || 'system',
 
     toggle(mode) {
       event.preventDefault()
@@ -105,9 +94,9 @@ Alpine.data('darkModeToggle', function () {
 
       if (mode !== 'system') {
         document.documentElement.classList.add(mode)
-        localStorage.theme = mode
+        localStorage._x_themeColor = mode
       } else {
-        localStorage.removeItem('theme')
+        localStorage.removeItem('_x_themeColor')
       }
 
       this.$refs.dropdown.removeAttribute('open')

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -83,4 +83,41 @@ Alpine.data('search', function () {
   }
 })
 
+Alpine.data('darkModeToggle', function () {
+  return {
+    currentMode: localStorage.getItem('theme') || 'system',
+
+    init() {
+      if (
+        localStorage.theme === 'dark' ||
+        (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)
+      ) {
+        document.documentElement.classList.add('dark')
+      } else {
+        document.documentElement.classList.remove('dark')
+      }
+    },
+
+    toggle(mode) {
+      event.preventDefault()
+
+      document.documentElement.classList.remove('dark')
+
+      if (mode !== 'system') {
+        document.documentElement.classList.add(mode)
+        localStorage.theme = mode
+      } else {
+        localStorage.removeItem('theme')
+      }
+
+      this.$refs.dropdown.removeAttribute('open')
+      this.currentMode = mode
+    },
+
+    isActive(mode) {
+      return this.currentMode === mode
+    },
+  }
+})
+
 Alpine.start()

--- a/resources/views/components/header/index.edge
+++ b/resources/views/components/header/index.edge
@@ -143,6 +143,46 @@
           <span class="bg-gray-300 dark:bg-darkGray-200 w-[2px] h-[20px] block"></span>
 
           <ul class="flex items-center space-x-4 ml-6">
+            <li class="relative nav_dropdown" x-data="darkModeToggle">
+              <details x-ref="dropdown">
+                <summary class="flex space-x-1 items-center cursor-pointer text-gray-600 dark:text-darkGray-600 font-medium tracking-[0.3px]">
+                  @svg('heroicons-outline:sun', {
+                    class: 'w-6 h-6 fill-gray-600 dark:fill-darkGray-600 mt-[3px]'
+                  })
+                </summary>
+
+                <div class="bg-white dark:bg-darkGray-800 absolute py-4 shadow-xl top-0 right-0 mt-10 z-50 rounded-md">
+                  <ul>
+                    <li>
+                      <a
+                        href="#"
+                        x-on:click="toggle('dark')"
+                        class="py-1.5 px-4 block text-gray-600 dark:text-darkGray-600 font-medium hover:text-gray-900 hover:text-gray-900 dark:hover:text-darkGray-900 whitespace-nowrap tracking-[0.3px]"
+                        :class="isActive('dark') && 'text-gray-900 dark:text-darkGray-900'"
+                      >
+                        Dark
+                      </a>
+                      <a
+                        href="#"
+                        x-on:click="toggle('light')"
+                        class="py-1.5 px-4 block text-gray-600 dark:text-darkGray-600 font-medium hover:text-gray-900 hover:text-gray-900 dark:hover:text-darkGray-900 whitespace-nowrap tracking-[0.3px]"
+                        :class="isActive('light') && 'text-gray-900 dark:text-darkGray-900'"
+                      >
+                        Light
+                      </a>
+                      <a
+                        href="#"
+                        x-on:click="toggle('system')"
+                        class="py-1.5 px-4 block text-gray-600 dark:text-darkGray-600 font-medium hover:text-gray-900 hover:text-gray-900 dark:hover:text-darkGray-900 whitespace-nowrap tracking-[0.3px]"
+                        :class="isActive('system') && 'text-gray-900 dark:text-darkGray-900'"
+                      >
+                        System
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+              </details>
+            </li>
             <li>
               <a
                 href="https://github.com/japa/runner"

--- a/resources/views/components/layouts/doc.edge
+++ b/resources/views/components/layouts/doc.edge
@@ -15,7 +15,10 @@
     @include('partials/icons')
 
     <script>
-      const theme = localStorage.getItem('_x_themeColor') || window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      let theme = localStorage.getItem('_x_themeColor');
+      if (!theme) {
+        theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+      }
       document.documentElement.classList.add(theme)
     </script>
 

--- a/resources/views/components/layouts/doc.edge
+++ b/resources/views/components/layouts/doc.edge
@@ -6,7 +6,7 @@
   @hide-sidebar.window="disableScroll = false"
   @show-header.window="disableScroll = true"
   @hide-header.window="disableScroll = false"
-  class="dark"
+  class=""
 >
   <head>
     <meta charset="UTF-8" />
@@ -27,7 +27,7 @@
     @entryPointScripts('app')
   </head>
   <body
-    class="font-display antialiased text-gray-900 dark:text-darkGray-900 bg-white dark:bg-darkGray-50"
+    class="font-display antialiased text-gray-900 dark:text-darkGray-900 bg-white dark:bg-darkGray-50 transition"
     :class="{ 'overflow-hidden': disableScroll }"
   >
     {{{ await $slots.main() }}}


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/japa/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

Not linked to any issue.
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
Added dark/light/system mode toggle for switching between dark, light, and system mode.

<!-- Why is this change required? What problem does it solve? -->
This only added the functionality of dark/light mode toggle on the top navbar

![image](https://user-images.githubusercontent.com/19237753/230018487-48185595-81a6-4656-a01a-2ae3ccd76068.png)


<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
NA

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
