### PR TITLE
doc(plugins): add help for type error about expect plugin

### DIFF
--- a/content/docs/plugins/expect.md
+++ b/content/docs/plugins/expect.md
@@ -63,4 +63,10 @@ test('add two numbers', ({ expect }) => {
 })
 ```
 
-In Jest, the `expect` property is available globally. However, with Japa, we recommend you always read it from the Test context.
+In Jest, the `expect` property is available globally. However, with Japa, we recommend you always read it from the Test context. If you're getting an error saying `expect` is not available from `TestContext`, make sure you included the bin folder in your `tsconfig.json` file:
+
+```json
+{
+  "include": ["bin", "src", "tests"]
+}
+```


### PR DESCRIPTION
When installing japa from the doc instructions, it is not mentioned to include the bin folder, which can lead to a TypeScript error saying expect is not available in TestContext type. Some people who aren't used that much to TypeScript can take a while to figure out what they're missing.

<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/japa/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

This is somehow related to issue https://github.com/japa/expect/issues/1

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 📄 Documentation

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
The point of this PR is just to add a small indication about including the bin folder in the tsconfig to avoid the type error
```
Property 'expect' does not exist on type 'TestContext'.
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
