### PR TITLE
fix: Fix broken link. Use 'develop' branch as found in code.

### DIFF
--- a/content/docs/guides/grouping_tests.md
+++ b/content/docs/guides/grouping_tests.md
@@ -2,7 +2,7 @@
 
 You may group a collection of tests using the `test.group` method. 
 
-The `test.group` method accepts the group title as the first parameter and a callback function as the second parameter. The callback function receives an instance of the [TestGroup](https://github.com/japa/core/blob/next/src/group/main.ts) class.
+The `test.group` method accepts the group title as the first parameter and a callback function as the second parameter. The callback function receives an instance of the [TestGroup](https://github.com/japa/core/blob/develop/src/group/main.ts) class.
 
 ```ts
 import { test } from '@japa/runner'

--- a/content/docs/guides/lifecycle_hooks.md
+++ b/content/docs/guides/lifecycle_hooks.md
@@ -160,7 +160,7 @@ test.group('Users.create', (group) => {
 As a general principle, you should always use cleanup functions when destroying the state created by the setup hook.
 
 ## Test hooks parameters
-The test lifecycle hooks receive an instance of the [Test class](https://github.com/japa/core/blob/develop/src/Test/index.ts) as the only argument.
+The test lifecycle hooks receive an instance of the [Test class](https://github.com/japa/core/blob/develop/src/test/main.ts) as the only argument.
 
 ```ts
 test.group((group) => {
@@ -190,7 +190,7 @@ test.group((group) => {
 ```
 
 ## Group hooks parameters
-The group lifecycle hooks receive an instance of the [Group class](https://github.com/japa/core/blob/develop/src/Group/index.ts) as the only argument.
+The group lifecycle hooks receive an instance of the [Group class](https://github.com/japa/core/blob/develop/src/group/main.ts) as the only argument.
 
 ```ts
 test.group((group) => {

--- a/content/docs/guides/test_reporters.md
+++ b/content/docs/guides/test_reporters.md
@@ -77,7 +77,7 @@ You can create and register custom test reporters with Japa. A test reporter mus
 
 Let's start by creating a reporter class. You can implement the following methods to listen for different events emitted during the test lifecycle.
 
-See also: [BaseReporter source code](https://github.com/japa/runner/blob/next/modules/core/reporters/base.ts)
+See also: [BaseReporter source code](https://github.com/japa/runner/blob/develop/modules/core/reporters/base.ts)
 
 ```ts
 import { BaseReporter } from '@japa/runner/core'

--- a/content/docs/reference/plugins.md
+++ b/content/docs/reference/plugins.md
@@ -26,9 +26,9 @@ emitter
 
 <dd>
 
-Reference to the [Emitter class](https://github.com/japa/core/blob/next/src/emitter.ts#L16). The emitter is responsible for emitting events reporting the progress of tests.
+Reference to the [Emitter class](https://github.com/japa/core/blob/develop/src/emitter.ts#L16). The emitter is responsible for emitting events reporting the progress of tests.
 
-Here's the [complete list](https://github.com/japa/core/blob/next/src/types.ts#L243) of emitted events.
+Here's the [complete list](https://github.com/japa/core/blob/develop/src/types.ts#L243) of emitted events.
 
 </dd>
 
@@ -40,7 +40,7 @@ runner
 
 <dd>
 
-Reference to an instance of the [Runner class](https://github.com/japa/core/blob/next/src/runner.ts#L32). The Runner class is responsible for executing the tests and also exposes API to register suites, reporters, and get the tests summary. 
+Reference to an instance of the [Runner class](https://github.com/japa/core/blob/develop/src/runner.ts#L32). The Runner class is responsible for executing the tests and also exposes API to register suites, reporters, and get the tests summary. 
 
 </dd>
 

--- a/content/docs/reference/test.md
+++ b/content/docs/reference/test.md
@@ -1,6 +1,6 @@
 # Test class
 
-Tests created using the `test` method are instances of the [Test class](https://github.com/japa/runner/blob/next/modules/core/main.ts#L57). You can invoke the following available class methods to configure the test further.
+Tests created using the `test` method are instances of the [Test class](https://github.com/japa/runner/blob/develop/modules/core/main.ts#L57). You can invoke the following available class methods to configure the test further.
 
 In this guide, we will go through all the methods and properties available on the test class.
 

--- a/content/docs/reference/test_context.md
+++ b/content/docs/reference/test_context.md
@@ -1,5 +1,5 @@
 # Test context
-An instance of the [TestContext](https://github.com/japa/runner/blob/next/modules/core/main.ts#L38) class is shared with all the tests and the test hooks. Japa creates an isolated instance of `TestContext` for every test. Therefore, you can add custom properties without worrying about it leaking to other tests.
+An instance of the [TestContext](https://github.com/japa/runner/blob/develop/modules/core/main.ts#L38) class is shared with all the tests and the test hooks. Japa creates an isolated instance of `TestContext` for every test. Therefore, you can add custom properties without worrying about it leaking to other tests.
 
 Based on your installed plugins, you may access different properties via the `ctx` object.
 


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/japa/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

I found some links reffering to other Japa repositories are using `next` branch. However, those branches are no longer available in repositories. 
- Fixed by changing the branch to `develop`.  

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
