### PR TITLE
fix: Fix fileSystem api - change write and writeJSON methods to create and createJson.

### DIFF
--- a/content/docs/plugins/file_system.md
+++ b/content/docs/plugins/file_system.md
@@ -44,7 +44,7 @@ Once the plugin has been registered, you can access the `fs` property from the [
 
 ```ts
 test('read rc file', async ({ fs }) => {
-  await fs.writeJSON('rc.json', {
+  await fs.createJson('rc.json', {
     foo: 'bar'
   })
 
@@ -318,7 +318,7 @@ Create a file at a given location. The missing directories will be created autom
 
 ```ts
 test('read rc file', async ({ fs }) => {
-  await fs.write('rc.json', JSON.stringify({
+  await fs.create('rc.json', JSON.stringify({
     foo: 'bar'
   }))
 })


### PR DESCRIPTION

<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/japa/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I found, that some FileSystem method calls are not correct - `fs.write` and `fs.writeJSON`.
- Fixed by replacing by `fs.create` and `fs.createJson`
  - `fs.create`: https://github.com/japa/file-system/blob/develop/src/file_system.ts#L70
  - `fs.createJson`: https://github.com/japa/file-system/blob/develop/src/file_system.ts#L148

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
