### PR TITLE
docs: Add documentation for openapi-assertions, remove old docs for assert plugin

### DIFF
--- a/content/docs/menu.json
+++ b/content/docs/menu.json
@@ -91,6 +91,11 @@
             "contentPath": "plugins/expect.md"
           },
           {
+            "title": "OpenAPI Assertions",
+            "permalink": "plugins/openapi-assertions",
+            "contentPath": "plugins/openapi-assertions.md"
+          },
+          {
             "title": "API Client",
             "permalink": "plugins/api-client",
             "contentPath": "plugins/api-client.md"

--- a/content/docs/plugins/assert.md
+++ b/content/docs/plugins/assert.md
@@ -63,40 +63,6 @@ test('add two numbers', ({ assert }) => {
 })
 ```
 
-## Open API testing
-Using this plugin, you can test HTTP responses against one or more open API schemas. Just make sure to register the path to schema files when using the plugin.
-
-```ts
-const config = {
-  openApi: {
-    schemas: [join(__dirname, '..', './api-schema.json')]
-  }
-}
-
-configure({
-  plugins: [
-    assert(config) // 👈 register config
-  ]
-})
-```
-
-Once done, you can test response objects from `axios`, `superagent`, `supertest`, `request`, and `light-my-request` libraries using the following method.
-
-```ts
-test('get /users', async ({ assert }) => {
-  const response = await supertest(baseUrl).get('/')
-  assert.isValidApiResponse(response)
-})
-```
-
-The response is validated as follows:
-
-- An error is raised if the request path is not documented in the API schema file.
-- An error is raised if the response status code is not documented in the API schema file.
-- An error is raised if the body properties are not the same as expected by the schema. Use the `required` array to validate required response properties.
-- The response status code is used to find the body schema for validation.
-- Response headers are also validated against the expected headers mentioned inside the API schema file.
-
 ## assert
 
 Assert an expression to be truthy. Then, optionally define the error message.

--- a/content/docs/plugins/openapi-assertions.md
+++ b/content/docs/plugins/openapi-assertions.md
@@ -1,0 +1,113 @@
+---
+title: OpenAPI Assertions
+description: OpenAPI Assertions plugin is used to validate responses against an OpenAPI specification.
+ogImage: openapi-assertions-plugin.jpeg
+---
+
+# OpenAPI Assertions
+
+Using this plugin, you can test HTTP responses against one or more open API schemas. Just make sure to register the path to schema files when using the plugin.
+
+## Setup
+
+Install the package from the npm registry as follows.
+
+```sh
+npm i -D @japa/api-client@1.4.4
+
+# yarn
+yarn add -D @japa/api-client@1.4.4
+```
+
+And register it as a plugin within the `bin/test.js` file.
+
+:::languageSwitcher
+
+```ts
+// title: ESM
+import { assert } from '@japa/assert'
+// highlight-start
+import { openapi } from '@japa/openapi-assertions'
+// highlight-end
+import { configure, processCliArgs } from '@japa/runner'
+
+configure({
+  ...processCliArgs(process.argv.slice(2)),
+  ...{
+    files: ['tests/**/*.spec.js'],
+    plugins: [
+      assert(),
+      // highlight-start
+      openapi({
+        schemas: [new URL('../api-spec.json', import.meta.url)]
+      })
+      // highlight-end
+    ]
+  }
+})
+```
+
+```ts
+// title: CommonJS
+const { assert } = require('@japa/assert')
+// highlight-start
+const { openapi } = require('@japa/openapi-assertions')
+const path = require('node:path')
+// highlight-end
+const { configure, processCliArgs } = require('@japa/runner')
+
+configure({
+  ...processCliArgs(process.argv.slice(2)),
+  ...{
+    files: ['tests/**/*.spec.js'],
+    plugins: [
+      assert(),
+      // highlight-start
+      openapi({
+        schemas: [path.resolve(__dirname, '../api-spec.json')]
+      })
+      // highlight-end
+    ]
+  }
+})
+```
+:::
+
+## Testing API Responses
+
+You can test response objects from `axios`, `superagent`, `supertest`, `request`, and `light-my-request` libraries using the following method.
+
+```ts
+test('get /users', async ({ openapi }) => {
+  const response = await supertest(baseUrl).get('/')
+  openapi.isValidResponse(response)
+})
+```
+
+The response is validated as follows:
+
+- An error is raised if the request path is not documented in the API schema file.
+- An error is raised if the response status code is not documented in the API schema file.
+- An error is raised if the body properties are not the same as expected by the schema. Use the `required` array to validate required response properties.
+- The response status code is used to find the body schema for validation.
+- Response headers are also validated against the expected headers mentioned inside the API schema file.
+
+## Migrating from `@japa/assert` v3.0.0
+
+To migrate from the OpenAPI testing in `@japa/assert` version 3.0.0, you need to configure the plugin as above, and then change from `assert.isValidApiResponse` to `openapi.isValidResponse`:
+
+```ts
+// title: Old Syntax
+test('get /users', async ({ assert }) => {
+  const response = await supertest(baseUrl).get('/')
+  assert.isValidApiResponse(response)
+})
+```
+
+```ts
+// title: New Syntax
+test('get /users', async ({ openapi }) => {
+  const response = await supertest(baseUrl).get('/')
+  openapi.isValidResponse(response)
+})
+```

--- a/content/docs/plugins/openapi-assertions.md
+++ b/content/docs/plugins/openapi-assertions.md
@@ -6,17 +6,17 @@ ogImage: openapi-assertions-plugin.jpeg
 
 # OpenAPI Assertions
 
-Using this plugin, you can test HTTP responses against one or more open API schemas. Just make sure to register the path to schema files when using the plugin.
+Using this plugin, you can test HTTP responses against one or more OpenAPI specifications. Just make sure to register the path to schema files when using the plugin.
 
 ## Setup
 
 Install the package from the npm registry as follows.
 
 ```sh
-npm i -D @japa/api-client@1.4.4
+npm i -D @japa/openapi-assertions@1.0.0
 
 # yarn
-yarn add -D @japa/api-client@1.4.4
+yarn add -D @japa/openapi-assertions@1.0.0
 ```
 
 And register it as a plugin within the `bin/test.js` file.
@@ -25,11 +25,11 @@ And register it as a plugin within the `bin/test.js` file.
 
 ```ts
 // title: ESM
+import { configure, processCliArgs } from '@japa/runner'
 import { assert } from '@japa/assert'
 // highlight-start
 import { openapi } from '@japa/openapi-assertions'
 // highlight-end
-import { configure, processCliArgs } from '@japa/runner'
 
 configure({
   ...processCliArgs(process.argv.slice(2)),
@@ -47,14 +47,14 @@ configure({
 })
 ```
 
-```ts
+```js
 // title: CommonJS
+const { configure, processCliArgs } = require('@japa/runner')
 const { assert } = require('@japa/assert')
 // highlight-start
 const { openapi } = require('@japa/openapi-assertions')
 const path = require('node:path')
 // highlight-end
-const { configure, processCliArgs } = require('@japa/runner')
 
 configure({
   ...processCliArgs(process.argv.slice(2)),
@@ -78,9 +78,9 @@ configure({
 You can test response objects from `axios`, `superagent`, `supertest`, `request`, and `light-my-request` libraries using the following method.
 
 ```ts
-test('get /users', async ({ openapi }) => {
+test('get /users', async ({ assert }) => {
   const response = await supertest(baseUrl).get('/')
-  openapi.isValidResponse(response)
+  assert.isValidApiResponse(response)
 })
 ```
 
@@ -94,20 +94,4 @@ The response is validated as follows:
 
 ## Migrating from `@japa/assert` v3.0.0
 
-To migrate from the OpenAPI testing in `@japa/assert` version 3.0.0, you need to configure the plugin as above, and then change from `assert.isValidApiResponse` to `openapi.isValidResponse`:
-
-```ts
-// title: Old Syntax
-test('get /users', async ({ assert }) => {
-  const response = await supertest(baseUrl).get('/')
-  assert.isValidApiResponse(response)
-})
-```
-
-```ts
-// title: New Syntax
-test('get /users', async ({ openapi }) => {
-  const response = await supertest(baseUrl).get('/')
-  openapi.isValidResponse(response)
-})
-```
+To migrate from the OpenAPI testing in `@japa/assert` version 3.0.0, you need to install and configure the plugin as above. No other changes should be necessary.


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/japa/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

n/a, created based on upstream changes.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is the accompanying documentation change for:
- https://github.com/japa/assert/pull/5
- https://github.com/japa/openapi-assertions/pull/1

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

### Rendered Documentation

![image](https://github.com/user-attachments/assets/5cadde87-3c2c-4596-a04b-77f962b1855c)
