### PR TITLE
docs: removed await in front of getSummary()

### DIFF
--- a/content/docs/guides/test_reporters.md
+++ b/content/docs/guides/test_reporters.md
@@ -182,7 +182,7 @@ Once all the tests have been executed, you can access the test summary within th
 ```ts
 class MyCustomReporter extends BaseReporter {
   async end() {
-    const summary = await this.runner.getSummary()
+    const summary = this.runner.getSummary()
     console.log(summary)
   }
 }
@@ -306,7 +306,7 @@ You may use the `this.printSummary` method to print the summary to the terminal 
 ```ts
 class MyCustomReporter extends BaseReporter {
   async end() {
-    const summary = await this.runner.getSummary()
+    const summary = this.runner.getSummary()
     await this.printSummary(summary)
   }
 }


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/japa/.github/blob/main/docs/CONTRIBUTING.md
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
The `this.runner.getSummary()` of `BaseReporter` is not returning a Promise, so there is no need for using `await`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
